### PR TITLE
Introduce the Kakfa consumer client on Elixir Kafka Lab

### DIFF
--- a/lib/kafka_elixir_lab/application.ex
+++ b/lib/kafka_elixir_lab/application.ex
@@ -6,10 +6,26 @@ defmodule KafkaElixirLab.Application do
   use Application
 
   def start(_type, _args) do
+    import Supervisor.Spec
+
     # List all child processes to be supervised
     children = [
       # Starts a worker by calling: KafkaElixirLab.Worker.start_link(arg)
-      KafkaElixirLab.AttackProducer
+      KafkaElixirLab.AttackProducer,
+      supervisor(
+        KafkaEx.ConsumerGroup,
+        [
+          KafkaElixirLab.ScalaPubConsumer,
+          "elixir-lab-consumer",
+          ["scala-pub"],
+          [
+            commit_interval: 5000,
+            commit_threshold: 100,
+            auto_offset_reset: :earliest,
+            heartbeat_interval: 1_000
+          ]
+        ]
+      )
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/kafka_elixir_lab/scala_pub_consumer.ex
+++ b/lib/kafka_elixir_lab/scala_pub_consumer.ex
@@ -1,0 +1,13 @@
+defmodule KafkaElixirLab.ScalaPubConsumer do
+  use KafkaEx.GenConsumer
+  alias KafkaEx.Protocol.Fetch.Message
+  require Logger
+
+  def handle_message_set(message_set, state) do
+    for message <- message_set do
+      Logger.debug(fn -> "message: " <> inspect(message) end)
+    end
+
+    {:async_commit, state}
+  end
+end


### PR DESCRIPTION
This commit adds the initial config to connect to a Kafka and
start consuming messages from configured topics.

The current implementation just ack any message from the beginning
(:earliest) and logs it in the console.