### PR TITLE
Unify topic for attacks

### DIFF
--- a/lib/kafka_elixir_lab/application.ex
+++ b/lib/kafka_elixir_lab/application.ex
@@ -16,8 +16,8 @@ defmodule KafkaElixirLab.Application do
         KafkaEx.ConsumerGroup,
         [
           KafkaElixirLab.ScalaPubConsumer,
-          "elixir-lab-consumer",
-          ["scala-pub"],
+          "kafka-lab-elixir-consumer",
+          ["attacks"],
           [
             commit_interval: 5000,
             commit_threshold: 100,

--- a/lib/kafka_elixir_lab/application.ex
+++ b/lib/kafka_elixir_lab/application.ex
@@ -21,7 +21,8 @@ defmodule KafkaElixirLab.Application do
           [
             commit_interval: 5000,
             commit_threshold: 100,
-            auto_offset_reset: :earliest,
+            enable_auto_commit: true,
+            auto_offset_reset: :latest,
             heartbeat_interval: 1_000
           ]
         ]

--- a/lib/kafka_elixir_lab/attack_consumer.ex
+++ b/lib/kafka_elixir_lab/attack_consumer.ex
@@ -3,10 +3,6 @@ defmodule KafkaElixirLab.ScalaPubConsumer do
   alias KafkaEx.Protocol.Fetch.Message
   require Logger
 
-  def partition_consumer_map(supervisor_pid) do
-    %{topic: "attacks", partition_id: 1}
-  end
-
   def handle_message_set(message_set, state) do
     for message <- message_set do
       Logger.debug(fn -> "message: " <> inspect(message) end)

--- a/lib/kafka_elixir_lab/attack_consumer.ex
+++ b/lib/kafka_elixir_lab/attack_consumer.ex
@@ -5,7 +5,11 @@ defmodule KafkaElixirLab.ScalaPubConsumer do
 
   def handle_message_set(message_set, state) do
     for message <- message_set do
-      Logger.debug(fn -> "message: " <> inspect(message) end)
+      if (message.key == "scala-pub") do
+        Logger.debug(fn -> "message: " <> inspect(message) end)
+      else
+        Logger.debug("I am not interested on my own messages:" <> inspect(message))
+      end
     end
 
     {:async_commit, state}

--- a/lib/kafka_elixir_lab/attack_consumer.ex
+++ b/lib/kafka_elixir_lab/attack_consumer.ex
@@ -1,11 +1,10 @@
 defmodule KafkaElixirLab.ScalaPubConsumer do
   use KafkaEx.GenConsumer
-  alias KafkaEx.Protocol.Fetch.Message
   require Logger
 
   def handle_message_set(message_set, state) do
     for message <- message_set do
-      if (message.key == "scala-pub") do
+      if message.key == "scala-pub" do
         Logger.debug(fn -> "message: " <> inspect(message) end)
       else
         Logger.debug("I am not interested on my own messages:" <> inspect(message))

--- a/lib/kafka_elixir_lab/attack_producer.ex
+++ b/lib/kafka_elixir_lab/attack_producer.ex
@@ -27,7 +27,7 @@ defmodule KafkaElixirLab.AttackProducer do
     {:noreply, state}
   end
 
-  defp schedule_shot(state) do
+  defp schedule_shot(_state) do
     # in 200ms
     Process.send_after(self(), :ok, 200)
   end

--- a/lib/kafka_elixir_lab/attack_producer.ex
+++ b/lib/kafka_elixir_lab/attack_producer.ex
@@ -1,5 +1,6 @@
 defmodule KafkaElixirLab.AttackProducer do
   use GenServer
+  alias KafkaEx.Protocol.Produce.{Message, Request}
   require Logger
 
   def start_link(args \\ %{}) do
@@ -15,11 +16,12 @@ defmodule KafkaElixirLab.AttackProducer do
   # -- Server Callbacks
 
   def handle_info(:ok, state) do
-    # publish kafka message here
-    Logger.info("TODO: publish a shot to Kafka")
-    random_number = :rand.uniform(10)
-    msg = "Rdn Num: " <> Integer.to_string(random_number)
-    KafkaEx.produce("elixir-pub", 0, msg)
+    attack = Integer.to_string(:rand.uniform(10))
+    msg = %Message{key: "elixir-pub", value: attack}
+    request = %Request{topic: "attacks", partition: 0, required_acks: 1, messages: [attack]}
+
+    KafkaEx.produce(request)
+    Logger.info("Published a shot with power " <> attack <> " to attacks topic")
     schedule_shot(state)
 
     {:noreply, state}

--- a/lib/kafka_elixir_lab/attack_producer.ex
+++ b/lib/kafka_elixir_lab/attack_producer.ex
@@ -18,7 +18,7 @@ defmodule KafkaElixirLab.AttackProducer do
   def handle_info(:ok, state) do
     attack = Integer.to_string(:rand.uniform(10))
     msg = %Message{key: "elixir-pub", value: attack}
-    request = %Request{topic: "attacks", partition: 0, required_acks: 1, messages: [attack]}
+    request = %Request{topic: "attacks", partition: 0, required_acks: 1, messages: [msg]}
 
     KafkaEx.produce(request)
     Logger.info("Published a shot with power " <> attack <> " to attacks topic")

--- a/lib/kafka_elixir_lab/scala_pub_consumer.ex
+++ b/lib/kafka_elixir_lab/scala_pub_consumer.ex
@@ -3,6 +3,10 @@ defmodule KafkaElixirLab.ScalaPubConsumer do
   alias KafkaEx.Protocol.Fetch.Message
   require Logger
 
+  def partition_consumer_map(supervisor_pid) do
+    %{topic: "attacks", partition_id: 1}
+  end
+
   def handle_message_set(message_set, state) do
     for message <- message_set do
       Logger.debug(fn -> "message: " <> inspect(message) end)


### PR DESCRIPTION
Now all players will produce and consume attacks from same topic. It will allow - if desired - to have multiple game rooms without many changes in the code.